### PR TITLE
feat(Bundle): drop support for CJS

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,11 +2,10 @@
   "name": "@blockcerts/hashlink-verifier",
   "version": "0.0.0-dev",
   "description": "Handling hashlinks in Blockcerts",
-  "main": "lib/cjs/HashlinkVerifier.js",
-  "import": "lib/esm/HashlinkVerifier.js",
+  "main": "lib/esm/HashlinkVerifier.js",
   "types": "lib/index.d.ts",
   "scripts": {
-    "compile": "npm run clean:build && tsc -p tsconfig.json && tsc -p tsconfig.cjs.json && npm run dts:bundle",
+    "compile": "npm run clean:build && tsc -p tsconfig.json && npm run dts:bundle",
     "clean:build": "rimraf lib",
     "dts:bundle": "dts-bundle-generator -o ./lib/index.d.ts --project tsconfig.json --no-banner src/HashlinkVerifier.ts",
     "lint": "eslint . --ext .ts",

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,7 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "module": "commonjs",
-    "outDir": "lib/cjs"
-  }
-}


### PR DESCRIPTION
BREAKING CHANGE: CJS code is not shipped anymore as part of the bundle. Only entry point is now ESM.